### PR TITLE
Fix: Windows paths

### DIFF
--- a/packages/plugma/lib/vite-plugins/vite-plugin-dot-env-loader.js
+++ b/packages/plugma/lib/vite-plugins/vite-plugin-dot-env-loader.js
@@ -33,6 +33,9 @@ export default function dotEnvLoader(options = {}) {
 
 		const env = { ...process.env };
 
+		delete env['CommonProgramFiles(x86)'];
+		delete env['ProgramFiles(x86)'];
+
 		envFiles.forEach((file) => {
 			if (fs.existsSync(file)) {
 				const content = fs.readFileSync(file, 'utf-8');

--- a/packages/plugma/scripts/utils.js
+++ b/packages/plugma/scripts/utils.js
@@ -225,16 +225,18 @@ function notifyOnRebuild() {
 	};
 }
 
+function replaceBackslashInString(stringPath) {
+	return path.sep === "\\"
+		? path.resolve(stringPath).split(path.sep).join('/')
+		: stringPath
+}
+
 function writeTempFile(fileName, userFiles, options) {
-	const tempFilePath = join(os.tmpdir(), fileName);
-	const bannerCode = fs.readFileSync(`${__dirname}/banner.js`, 'utf8')
-	const injectedCode = bannerCode.replace('let runtimeData', `let runtimeData = ${JSON.stringify(options)};`);
-	const modifiedContent = `import plugmaMain from "${CURR_DIR}/${userFiles.manifest.main}";
+	const tempFilePath = path.join(os.tmpdir(), fileName);
+	const modifiedContentPath = replaceBackslashInString(path.join(CURR_DIR, userFiles.manifest.main))
+	const modifiedContent = `import plugmaMain from "${modifiedContentPath}";
 		plugmaMain();`;
-
-
 	fs.writeFileSync(tempFilePath, modifiedContent);
-
 	return tempFilePath;
 }
 


### PR DESCRIPTION
This PR fixes a couple of issues for users on Windows operating systems.

The path added with writeTempFile - replace \\ on windows with / for the import statement
delete programFiles(x86) process.env vars  - causing an issue with vite and the .env loader