### PR TITLE
svelte-ts template missing prop definitions in components

### DIFF
--- a/packages/create-plugma/templates/svelte-ts/src/components/Button.svelte
+++ b/packages/create-plugma/templates/svelte-ts/src/components/Button.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-	let { children, href, target, style, onclick } = $props()
+	interface Props {
+        children: () => any;
+        href?: string;
+        target?: string;
+        style?: string;
+        onclick?: () => void;
+	}
+
+	let { children, href, target, style, onclick }: Props = $props()
 </script>
 
 {#if href}

--- a/packages/create-plugma/templates/svelte-ts/src/components/Input.svelte
+++ b/packages/create-plugma/templates/svelte-ts/src/components/Input.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	let { value = $bindable(''), type = 'text', showIcon } = $props()
+	interface Props {
+		value?: string | number
+		type?: string
+		showIcon?: boolean
+	}
+
+	let { value = $bindable(''), type = 'text', showIcon }: Props = $props()
 </script>
 
 <div class="Input" data-non-interactive="true">


### PR DESCRIPTION
Adding prop definitions to Button and Input components in svelte-ts template